### PR TITLE
Implement replaceable HTTP Client

### DIFF
--- a/solvedac_community/HTTPClients/__init__.py
+++ b/solvedac_community/HTTPClients/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from .abstract_http_client import AbstractHTTPClient
+from .httpclient import HTTPClientLibrary
+from .httpclient import RequestMethod
+from .httpclient import ResponseData
+from .httpclient import Route
+from .httpclient import get_http_client

--- a/solvedac_community/HTTPClients/abstract_http_client.py
+++ b/solvedac_community/HTTPClients/abstract_http_client.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+from abc import *
+from typing import Optional, Dict
+
+from .httpclient import ResponseData, Route
+
+
+class AbstractHTTPClient(metaclass=ABCMeta):
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    async def request(self, route: Route, headers: Optional[Dict[str, str]] = None) -> ResponseData:
+        pass

--- a/solvedac_community/HTTPClients/aiohttp_client.py
+++ b/solvedac_community/HTTPClients/aiohttp_client.py
@@ -15,57 +15,15 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 import asyncio
 import atexit
-from enum import Enum
-from typing import ClassVar, Optional, Dict, Any, Union
+from typing import ClassVar, Optional, Union, Dict
 
 import aiohttp
 
-
-class Missing:
-    pass
-
-
-MISSING: Any = Missing()
+from .abstract_http_client import AbstractHTTPClient
+from .httpclient import MISSING, ResponseData, Route
 
 
-class RequestMethod(Enum):
-    GET = 0
-    POST = 1
-    PUT = 2
-    HEAD = 3
-    DELETE = 4
-    PATCH = 5
-    OPTIONS = 6
-
-
-class Route:
-    BASE_URL: ClassVar[str] = "https://solved.ac/api/v3"
-
-    @staticmethod
-    def __make_url(url: str, params: dict) -> str:
-        first: bool = True
-        for key, val in params.items():
-            url += "%s%s=%s" % ("?" if first else "&", key, str(val))
-            first = False
-        return url
-
-    def __init__(self, method: RequestMethod, url: str, params: Optional[Dict[str, Any]] = None) -> None:
-        if params:
-            url = self.__make_url(url, params)
-        (self.url): str = self.BASE_URL + url
-        (self.method): RequestMethod = method
-
-
-class ResponseData:
-    def __init__(self, text: str, status: int) -> None:
-        (self.response_data): str = text
-        (self.status): int = status
-
-    def __str__(self) -> str:
-        return f"status_code : {self.status}\nresponse_data : {self.response_data}"
-
-
-class HTTPClient:
+class AiohttpHTTPClient(AbstractHTTPClient):
     USER_AGENT: ClassVar[str] = "Mozilla/5.0"
 
     def __new__(cls, *args, **kwargs):
@@ -74,10 +32,10 @@ class HTTPClient:
         return cls._instance
 
     def __init__(self, loop: asyncio.AbstractEventLoop, solvedac_token: Optional[str] = None) -> None:
-        (self.loop): asyncio.AbstractEventLoop = loop
-        (self.session): aiohttp.ClientSession = MISSING
-        (self.lock): asyncio.Lock = asyncio.Lock()
-        (self.solvedac_token): Union[str, None] = solvedac_token
+        self.loop: asyncio.AbstractEventLoop = loop
+        self.session: aiohttp.ClientSession = MISSING
+        self.lock: asyncio.Lock = asyncio.Lock()
+        self.solvedac_token: Union[str, None] = solvedac_token
         atexit.register(self.close)
 
     async def request(self, route: Route, headers: Optional[Dict[str, str]] = None) -> ResponseData:
@@ -86,9 +44,6 @@ class HTTPClient:
 
         default_header = {"User-Agent": self.USER_AGENT, "Accept": "application/json"}
         headers.update(default_header)
-
-        if not __debug__:
-            print(route.url)
 
         if self.session == MISSING:
             if self.solvedac_token is not None:

--- a/solvedac_community/HTTPClients/httpclient.py
+++ b/solvedac_community/HTTPClients/httpclient.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import asyncio
+from enum import Enum, auto
+from typing import ClassVar, Optional, Dict, Any
+
+
+class Missing:
+    pass
+
+
+MISSING: Any = Missing()
+
+
+class HTTPClientLibrary(Enum):
+    AIOHTTP = auto()
+    HTTPX = auto()
+
+
+def get_http_client(
+    loop: asyncio.AbstractEventLoop, solvedac_token: Optional[str] = None, lib: Optional[HTTPClientLibrary] = None
+):
+    if lib is None:
+        try:
+            import aiohttp
+            from .aiohttp_client import AiohttpHTTPClient
+
+            return AiohttpHTTPClient(loop, solvedac_token)
+        except ImportError:
+            pass
+
+        try:
+            import httpx
+            from .httpx_client import HttpxHTTPClient
+
+            return HttpxHTTPClient(loop, solvedac_token)
+        except ImportError:
+            pass
+
+        raise ImportError("At least one of aiohttp or httpx libraries is required")
+
+    if lib == HTTPClientLibrary.HTTPX:
+        from .httpx_client import HttpxHTTPClient
+
+        return HttpxHTTPClient(loop, solvedac_token)
+
+    elif lib == HTTPClientLibrary.AIOHTTP:
+        from .aiohttp_client import AiohttpHTTPClient
+
+        return AiohttpHTTPClient(loop, solvedac_token)
+
+
+class RequestMethod(Enum):
+    GET = 0
+    POST = 1
+    PUT = 2
+    HEAD = 3
+    DELETE = 4
+    PATCH = 5
+    OPTIONS = 6
+
+
+class Route:
+    BASE_URL: ClassVar[str] = "https://solved.ac/api/v3"
+
+    @staticmethod
+    def __make_url(url: str, params: dict) -> str:
+        first: bool = True
+        for key, val in params.items():
+            url += "%s%s=%s" % ("?" if first else "&", key, str(val))
+            first = False
+        return url
+
+    def __init__(self, method: RequestMethod, url: str, params: Optional[Dict[str, Any]] = None) -> None:
+        if params:
+            url = self.__make_url(url, params)
+        (self.url): str = self.BASE_URL + url
+        (self.method): RequestMethod = method
+
+
+class ResponseData:
+    def __init__(self, text: str, status: int) -> None:
+        (self.response_data): str = text
+        (self.status): int = status
+
+    def __str__(self) -> str:
+        return f"status_code : {self.status}\nresponse_data : {self.response_data}"

--- a/solvedac_community/HTTPClients/httpx_client.py
+++ b/solvedac_community/HTTPClients/httpx_client.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright (c) 2023 DevRuby
+MIT License
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import asyncio
+from typing import ClassVar, Optional, Union, Dict
+
+import httpx
+
+from .abstract_http_client import AbstractHTTPClient
+from .httpclient import ResponseData, Route
+
+
+class HttpxHTTPClient(AbstractHTTPClient):
+    USER_AGENT: ClassVar[str] = "Mozilla/5.0"
+
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, loop: asyncio.AbstractEventLoop, solvedac_token: Optional[str] = None) -> None:
+        self.loop: asyncio.AbstractEventLoop = loop
+        self.lock: asyncio.Lock = asyncio.Lock()
+        self.solvedac_token: Union[str, None] = solvedac_token
+
+    async def request(self, route: Route, headers: Optional[Dict[str, str]] = None) -> ResponseData:
+        if not headers:
+            headers = {}
+
+        default_header = {"User-Agent": self.USER_AGENT, "Accept": "application/json"}
+        headers.update(default_header)
+
+        async with self.lock:
+            async with httpx.AsyncClient(
+                cookies={"solvedacToken": self.solvedac_token} if self.solvedac_token else None
+            ) as client:
+                response: httpx.Response = await client.request(
+                    method=route.method.name, url=route.url, headers=headers
+                )
+                status: int = response.status_code
+                text: str = response.text
+                return ResponseData(text, status)

--- a/solvedac_community/__init__.py
+++ b/solvedac_community/__init__.py
@@ -11,17 +11,21 @@ An API Wrapper for SolvedAC API
 Copyright (c) 2023 DevRuby
 """
 
-"""
-Copyright (c) 2023 DevRuby
-MIT License
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NON INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-"""
-
 from .client import Client
+
+count = 0
+
+try:
+    import aiohttp
+    count += 1
+except ImportError:
+    pass
+
+try:
+    import httpx
+    count += 1
+except ImportError:
+    pass
+
+if count == 0:
+    raise ImportError("\nAt least one of aiohttp or httpx libraries is required\nTry `pip install aiohttp` or `pip install httpx`")

--- a/solvedac_community/client.py
+++ b/solvedac_community/client.py
@@ -17,25 +17,21 @@ import asyncio
 import json
 from typing import Optional, List, Iterable, Union
 
+from .HTTPClients import *
 from .Models import *
-
-from .httpclient import HTTPClient
-from .httpclient import RequestMethod
-from .httpclient import ResponseData
-from .httpclient import Route
 
 
 class Client:
     loop: asyncio.AbstractEventLoop
-    http_client: HTTPClient
+    http_client: AbstractHTTPClient
 
-    def __init__(self, solvedac_token: Optional[str] = None) -> None:
+    def __init__(self, solvedac_token: Optional[str] = None, http_library: HTTPClientLibrary = None) -> None:
         try:
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
         except AttributeError:
             pass
         self.loop = asyncio.get_event_loop()
-        self.http_client = HTTPClient(self.loop, solvedac_token)
+        self.http_client = get_http_client(self.loop, solvedac_token=solvedac_token, lib=http_library)
 
     async def get_user(self, handle: str) -> User:
         response: ResponseData = await self.http_client.request(


### PR DESCRIPTION
- solvedac_community/HTTPClients/httpclient.py: Add `get_http_client` method; Move`AiohttpHTTPClient` to `solvedac_community/HTTPClients/aiohttp_client.py`
- solvedac_community/HTTPClients/abstract_http_client.py: Add `AbstractHTTPClient` abstract class
- solvedac_community/HTTPClients/aiohttp_client.py: Add `AiohttpHTTPClient` class
- solvedac_community/HTTPClients/httpx_clinet.py: Add `HttpxHTTPClient` class
- solvedac_community/HTTPClients/__init__.py: Import `AbstractHTTPClient` class, `HTTPClientLibrary` class, `RequestMethod` class, `ResponseData` class, `Route` class, `get_http_client` method
- solvedac_community/__init__.py: Check modules