### PR TITLE
Remove Singleton pattern from HTTP client

### DIFF
--- a/solvedac_community/HTTPClients/abstract_http_client.py
+++ b/solvedac_community/HTTPClients/abstract_http_client.py
@@ -20,10 +20,6 @@ from .httpclient import ResponseData, Route
 
 
 class AbstractHTTPClient(metaclass=ABCMeta):
-    def __new__(cls, *args, **kwargs):
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
 
     @abstractmethod
     def __init__(self):

--- a/solvedac_community/HTTPClients/aiohttp_client.py
+++ b/solvedac_community/HTTPClients/aiohttp_client.py
@@ -26,11 +26,6 @@ from .httpclient import MISSING, ResponseData, Route
 class AiohttpHTTPClient(AbstractHTTPClient):
     USER_AGENT: ClassVar[str] = "Mozilla/5.0"
 
-    def __new__(cls, *args, **kwargs):
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
     def __init__(self, loop: asyncio.AbstractEventLoop, solvedac_token: Optional[str] = None) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.session: aiohttp.ClientSession = MISSING

--- a/solvedac_community/HTTPClients/httpclient.py
+++ b/solvedac_community/HTTPClients/httpclient.py
@@ -87,14 +87,14 @@ class Route:
     def __init__(self, method: RequestMethod, url: str, params: Optional[Dict[str, Any]] = None) -> None:
         if params:
             url = self.__make_url(url, params)
-        (self.url): str = self.BASE_URL + url
-        (self.method): RequestMethod = method
+        self.url: str = self.BASE_URL + url
+        self.method: RequestMethod = method
 
 
 class ResponseData:
     def __init__(self, text: str, status: int) -> None:
-        (self.response_data): str = text
-        (self.status): int = status
+        self.response_data: str = text
+        self.status: int = status
 
     def __str__(self) -> str:
         return f"status_code : {self.status}\nresponse_data : {self.response_data}"

--- a/solvedac_community/HTTPClients/httpx_client.py
+++ b/solvedac_community/HTTPClients/httpx_client.py
@@ -25,11 +25,6 @@ from .httpclient import ResponseData, Route
 class HttpxHTTPClient(AbstractHTTPClient):
     USER_AGENT: ClassVar[str] = "Mozilla/5.0"
 
-    def __new__(cls, *args, **kwargs):
-        if not hasattr(cls, "_instance"):
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
     def __init__(self, loop: asyncio.AbstractEventLoop, solvedac_token: Optional[str] = None) -> None:
         self.loop: asyncio.AbstractEventLoop = loop
         self.lock: asyncio.Lock = asyncio.Lock()


### PR DESCRIPTION
# Summary

HTTP 클라이언트의 싱글톤 패턴 구현 제거

</br>

# Purpose

- SolvedAC API 값을 여러개 넣고 사용할 경우, 싱글톤 패턴으로 구현된 현재의 HTTP Client로는 불편한 점이 매우 많음
- 이러한 현상을 해결하기 위해 싱글톤 패턴 제거

</br>

# Changes

- Remove Singleton pattern from HTTP client
- Remove unnecessary parentheses

</br>
