### PR TITLE
Change HTTP response status code assertion to 204 in `update_account_settings` method

### DIFF
--- a/solvedac_community/client.py
+++ b/solvedac_community/client.py
@@ -157,4 +157,4 @@ class Client:
             Route(RequestMethod.PATCH, "/account/update_settings"), body={"key" : key, "value" :  value}
         )
 
-        assert response.status == 200, "HTTP Response Status Code is not 200\nStatus Code : %d" % response.status
+        assert response.status == 204, "HTTP Response Status Code is not 204\nStatus Code : %d" % response.status


### PR DESCRIPTION
# Summary

assert문에서 200이 아닌 204로 검사

</br>

# Purpose

- 해당 Endpoint는 요청 성공 시 204 코드 반환
- 이전에는 요청에 성공해도 assert error가 발생

</br>

# Changes

- Change HTTP response status code assertion to 204 in `update_account_settings` method

</br>
